### PR TITLE
Don't cast stagger axis and index to int

### DIFF
--- a/pytiled_parser/xml_parser.py
+++ b/pytiled_parser/xml_parser.py
@@ -926,12 +926,12 @@ def parse_tile_map(tmx_file: Union[str, Path]) -> objects.TileMap:
         pass
 
     try:
-        tile_map.stagger_axis = int(map_element.attrib["staggeraxis"])
+        tile_map.stagger_axis = map_element.attrib["staggeraxis"]
     except KeyError:
         pass
 
     try:
-        tile_map.stagger_index = int(map_element.attrib["staggerindex"])
+        tile_map.stagger_index = map_element.attrib["staggerindex"]
     except KeyError:
         pass
 


### PR DESCRIPTION
Tiled maps' "staggeraxis" and "staggerindex" attributes (at least as of version 1.3.3) are string attributes and can not be casted to int.

I tried parsing a very basic map and faced the following exception:
```
>>> from pytiled_parser import parse_tile_map
>>> parse_tile_map('map.tmx')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/sandorlev/Projects/FourOnTheFloor/.venv/fotf/lib/python3.6/site-packages/pytiled_parser/xml_parser.py", line 947, in parse_tile_map
    tile_map.stagger_axis = int(map_element.attrib["staggeraxis"])
ValueError: invalid literal for int() with base 10: 'y'
```
Then I took a look at the tmx file:
```
<map version="1.2" tiledversion="1.3.3" orientation="staggered" renderorder="left-down" width="10" height="10" tilewidth="32" tileheight="16" infinite="0" staggeraxis="y" staggerindex="odd" nextlayerid="2" nextobjectid="1">
```
You can see "staggeraxis" and "staggerindex" are both strings.
I'm a fresh user of Tiled so not sure if this is a change from previous Tiled versions or just something that hasn't come up yet in the lifetime of pytiled_parser, so let me know what you think!