### PR TITLE
unify property handling, fixes #16 - WARNING: breaks API

### DIFF
--- a/pytiled_parser/objects.py
+++ b/pytiled_parser/objects.py
@@ -38,18 +38,6 @@ class OrderedPair(NamedTuple):
     y: Union[int, float]
 
 
-class Property(NamedTuple):
-    """OrderedPair NamedTuple.
-
-    Attributes:
-        name str: Name of property
-        value str: Value of property
-    """
-
-    name: str
-    value: str
-
-
 class Size(NamedTuple):
     """Size NamedTuple.
 
@@ -483,7 +471,7 @@ class Tile:
     animation: Optional[List[Frame]] = None
     objectgroup: Optional[List[TiledObject]] = None
     image: Optional[Image] = None
-    properties: Optional[List[Property]] = None
+    properties: Optional[Properties] = None
     tileset: Optional[TileSet] = None
     flipped_horizontally: bool = False
     flipped_diagonally: bool = False

--- a/pytiled_parser/xml_parser.py
+++ b/pytiled_parser/xml_parser.py
@@ -530,16 +530,11 @@ def _parse_tiles(
             terrain = objects.TileTerrain(*terrain_list)
 
         # tile element optional sub-elements
-        properties: Optional[List[objects.Property]] = None
+        properties: Optional[Properties] = None
         tile_properties_element = tile_element.find("./properties")
+        
         if tile_properties_element:
-            properties = []
-            property_list = tile_properties_element.findall("./property")
-            for property_ in property_list:
-                name = property_.attrib["name"]
-                value = property_.attrib["value"]
-                obj = objects.Property(name, value)
-                properties.append(obj)
+            properties = _parse_properties_element(tile_properties_element)
 
         # tile element optional sub-elements
         animation: Optional[List[objects.Frame]] = None


### PR DESCRIPTION
uses _parse_properties_element to parse tile properties. The properties are then stored as Properties object, no longer as List[Property], see #16 for reasoning.

As the type Property is no longer needed, it has been removed.